### PR TITLE
GH4: Bump dependencies to reduce Cake warnings

### DIFF
--- a/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
+++ b/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
@@ -5,12 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.30.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Cake.Testing" Version="0.30.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Testing" Version="0.33.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
+++ b/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerTests.cs
+++ b/Source/Cake.DotNetTool.Module.Tests/DotNetToolPackageInstallerTests.cs
@@ -78,6 +78,7 @@ namespace Cake.DotNetTool.Module.Tests
 
         public sealed class TheCanInstallMethod
         {
+            [Fact]
             public void Should_Throw_If_URI_Is_Null()
             {
                 // Given

--- a/Source/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
+++ b/Source/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.30.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.30.0" />
+    <package id="Cake" version="0.32.1" />
 </packages>


### PR DESCRIPTION
Fixes #4 

Note: [tools/packages.config](https://github.com/gitfool/Cake.DotNetTool.Module/blob/0570ca258f2cdf78a16b4ec4c6aea4c50f07d499/tools/packages.config#L3) limited to `Cake` 0.32.1 to avoid current issues with `Cake.Recipe`.