### PR TITLE
Fixed issue #13 typo in dotnet '--configfile' argument.

### DIFF
--- a/Source/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
+++ b/Source/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
@@ -237,7 +237,7 @@ namespace Cake.DotNetTool.Module
             // Config File
             if(definition.Parameters.ContainsKey("configfile"))
             {
-                arguments.Append("--config-file");
+                arguments.Append("--configfile");
                 arguments.AppendQuoted(definition.Parameters["configfile"].First());
             }
 


### PR DESCRIPTION
## Description
Fixed a typo for the dotnet '--configfile' argument.

## Related Issue
#13 

## Motivation and Context
Fixed an invalid usage of the dotnet CLI.

## How Has This Been Tested?
Manually copied the build output to the modules directory and added `&configfile=` argument to the package reference.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
