### PR TITLE
Added support for `--ignore-failed-sources` argument.

### DIFF
--- a/Source/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
+++ b/Source/Cake.DotNetTool.Module/DotNetToolPackageInstaller.cs
@@ -241,6 +241,12 @@ namespace Cake.DotNetTool.Module
                 arguments.AppendQuoted(definition.Parameters["configfile"].First());
             }
 
+            // Whether to ignore failed sources
+            if(definition.Parameters.ContainsKey("ignore-failed-sources"))
+            {
+                arguments.Append("--ignore-failed-sources");
+            }
+
             // Framework
             if (definition.Parameters.ContainsKey("framework"))
             {

--- a/docs/input/docs/usage/parameters.md
+++ b/docs/input/docs/usage/parameters.md
@@ -50,6 +50,16 @@ If you need to specify a NuGet config file, for example you need to authenticate
 #tool dotnet:?package=Octopus.DotNet.Cli&version=4.41.0&configfile="../../NuGet.config"
 ```
 
+# Ignore failed sources
+
+There might be cases where you want to ignore failed NuGet sources as long as the package could be restored.
+
+## Example
+
+```
+#tool dotnet:?package=Octopus.DotNet.Cli&version=4.41.0&ignore-failed-sources"
+```
+
 # Framework
 
 Specifies the [target framework](https://docs.microsoft.com/en-us/dotnet/standard/frameworks) to install the tool for. By default, the .NET Core SDK tries to choose the most appropriate target framework.


### PR DESCRIPTION
## Description
Added support for `--ignore-failed-sources` argument.

## Related Issue
#14 

## Motivation and Context
We have several private NuGet feeds which require authentication. Unfortunately, authentication information is not available when running the `dotnet` tool via cake in Azure DevOps Server builds.

## How Has This Been Tested?
Manually copied the build output to the modules directory and added `&ignore-failed-sources` argument to the package reference.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
