### PR TITLE
GH-23: Update Cake.DotNetTool.Module to target Cake v1.0.0

### DIFF
--- a/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
+++ b/Source/Cake.DotNetTool.Module.Tests/Cake.DotNetTool.Module.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="Cake.Testing" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Testing" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Source/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
+++ b/Source/Cake.DotNetTool.Module/Cake.DotNetTool.Module.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #23 